### PR TITLE
fix: Case where currentTG and desiredTG are replaced

### DIFF
--- a/pkg/provider/resource_courier_alb.go
+++ b/pkg/provider/resource_courier_alb.go
@@ -167,6 +167,14 @@ func createOrUpdateCourierALB(d *schema.ResourceData) error {
 		r1, err := svc.DescribeTargetGroups(&elbv2.DescribeTargetGroupsInput{
 			TargetGroupArns: []*string{
 				aws.String(nextTGARN),
+			},
+		})
+		if err != nil {
+			return err
+		}
+
+		r2, err := svc.DescribeTargetGroups(&elbv2.DescribeTargetGroupsInput{
+			TargetGroupArns: []*string{
 				aws.String(prevTGARN),
 			},
 		})
@@ -186,7 +194,7 @@ func createOrUpdateCourierALB(d *schema.ResourceData) error {
 			Rule:           rule,
 			ALBAttachments: nil,
 			DesiredTG:      r1.TargetGroups[0],
-			CurrentTG:      r1.TargetGroups[1],
+			CurrentTG:      r2.TargetGroups[0],
 			DeletedTGs:     nil,
 			Metrics:        metrics,
 		}


### PR DESCRIPTION
I found a case where the currentTG and the desiredTG were unintentionally swapped.

I set the courier.tf as follows.
My expectations are tg1 for currentTG and tg2 for desiredTG.
But in reality it was the opposite...

I think that the cause is the return values ​​of elbv2.DescribeTargetGroupsInput are in no particular order.
Therefore, I modified to get the currentTG and desiredTG separately.

- courier.tf
```HCL
/*
# couier lb
*/
resource "eksctl_courier_alb" "migration" {
  listener_arn = data.terraform_remote_state.lb.outputs.tmnakagawa-listener.arn
  priority      = "10"
  path_patterns = ["/*"]
  destination {
    target_group_arn = aws_lb_target_group.tg1.arn
    weight           = 0
  }
  destination {
    target_group_arn = aws_lb_target_group.tg2.arn
    weight           = 100
  }
  step_weight   = 30
  step_interval = "1m"
  depends_on = [
    helmfile_release_set.greenFirst,
  ]
}
```

- terraform apply debug
```
-snip-
2020-09-15T16:35:14.914+0900 [DEBUG] plugin.terraform-provider-eksctl_v0.7.5: 2020/09/15 16:35:14 Setting weight to DesiredTG tmn-tg1: Weight 1, CurrentTG tmn-tg2: Weight 99.
2020-09-15T16:36:14.917+0900 [DEBUG] plugin.terraform-provider-eksctl_v0.7.5: 2020/09/15 16:36:14 Setting weight to DesiredTG tmn-tg1: Weight 31, CurrentTG tmn-tg2: Weight 69.
2020-09-15T16:37:14.917+0900 [DEBUG] plugin.terraform-provider-eksctl_v0.7.5: 2020/09/15 16:37:14 Setting weight to DesiredTG tmn-tg1: Weight 61, CurrentTG tmn-tg2: Weight 39.
2020-09-15T16:38:14.918+0900 [DEBUG] plugin.terraform-provider-eksctl_v0.7.5: 2020/09/15 16:38:14 Setting weight to DesiredTG tmn-tg1: Weight 91, CurrentTG tmn-tg2: Weight 9.
2020-09-15T16:39:14.919+0900 [DEBUG] plugin.terraform-provider-eksctl_v0.7.5: 2020/09/15 16:39:14 Setting weight to DesiredTG tmn-tg1: Weight 100, CurrentTG tmn-tg2: Weight 0.
-snip-
```

- elbv2.DescribeTargetGroupsInput return
```
2020-09-15T16:55:28.580+0900 [DEBUG] plugin.terraform-provider-eksctl_v0.7.5: 2020/09/15 16:55:28 Debug: DesiredTG:{
-snip-
2020-09-15T16:55:28.580+0900 [DEBUG] plugin.terraform-provider-eksctl_v0.7.5:   TargetGroupArn: "arn:aws:elasticloadbalancing:ap-northeast-1:167855287371:targetgroup/tmn-tg1/c5dccc7dc04ad9e1",
2020-09-15T16:55:28.580+0900 [DEBUG] plugin.terraform-provider-eksctl_v0.7.5: }, CurrentTG:{
-snip-
2020-09-15T16:55:28.580+0900 [DEBUG] plugin.terraform-provider-eksctl_v0.7.5:   TargetGroupArn: "arn:aws:elasticloadbalancing:ap-northeast-1:167855287371:targetgroup/tmn-tg2/aef2d1d3020e334a",
-tg2",
```