### PR TITLE
feat: change the behavior of schema KeyKubeconfigPath

### DIFF
--- a/pkg/resource/cluster/resource.go
+++ b/pkg/resource/cluster/resource.go
@@ -189,7 +189,8 @@ func ResourceCluster() *schema.Resource {
 			},
 			KeyKubeconfigPath: {
 				Type:     schema.TypeString,
-				Computed: true,
+				Optional: true,
+				Default:  "",
 			},
 			// spec is the string containing the part of eksctl cluster.yaml
 			// Over time the provider adds HCL-native syntax for any of cluster.yaml items.


### PR DESCRIPTION
Hi, Thank you always!

The suggestion for this PR is to allow the user to control the path of kubeconfig.

"Kubeconfig_path" is defined as an optional parameter
By default, "kubeconfig" is generated in the tmp area.
Also, if i want to inherit "kubeconfig" in another environment, i set the parameter "kubeconfig_path". (Example: CI)

default setting 'kubeconfig_path is null'
- terraform.tf
```
resource "eksctl_cluster" "blue" {
  eksctl_bin  = "eksctl"
  name        = "sandbox-tmnakagawa-1"
  region      = "ap-northeast-1"
  api_version = "eksctl.io/v1alpha5"
  version     = "1.14"
  vpc_id      = data.terraform_remote_state.vpc.outputs.vpc_id
  revision    = 1
  spec = <<EOS
-snip-
```
 
- terraform output
```
Apply complete! Resources: 2 added, 0 changed, 0 destroyed.
Outputs:
azs = [
  "ap-northeast-1a",
  "ap-northeast-1c",
  "ap-northeast-1d",
]
caller_id = 167855287371
kubeconfig_path_blue = /var/folders/8g/cj5brb115g1369knxjwyb_351xk4ng/T/tf-eksctl-kubeconfig482863336
region = ap-northeast-1
user_id = infra
```

add setting "kubeconfig_path"
- terraform.tf
```
resource "eksctl_cluster" "blue" {
  eksctl_bin  = "eksctl"
  name        = "sandbox-tmnakagawa-1"
  region      = "ap-northeast-1"
  api_version = "eksctl.io/v1alpha5"
  version     = "1.14"
  vpc_id      = data.terraform_remote_state.vpc.outputs.vpc_id
  kubeconfig_path = "kubeconfig/sandbox-tmnakagawa-1" <<< here!!
  revision    = 1
  spec = <<EOS
-snip-
```
 
- terraform output
```
Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
Outputs:
azs = [
  "ap-northeast-1a",
  "ap-northeast-1c",
  "ap-northeast-1d",
]
caller_id = 167855287371
kubeconfig_path_blue = kubeconfig/sandbox-tmnakagawa-1 <<< here!!
region = ap-northeast-1
user_id = infra
```
