### PR TITLE
Always update IAM Identity Mappings

### DIFF
--- a/pkg/resource/cluster/cluster_update.go
+++ b/pkg/resource/cluster/cluster_update.go
@@ -273,7 +273,7 @@ func (m *Manager) updateCluster(d *schema.ResourceData) error {
 		createNew("fargateprofile", nil, harmlessFargateProfileCreationErrors),
 		enableRepo(),
 		draineNodegroup(),
-		whenIAMWithOIDCEnabled(updateIAMIdentityMapping()),
+		updateIAMIdentityMapping(),
 		deleteMissing("nodegroup", []string{"--drain", "--approve"}, nil),
 		whenIAMWithOIDCEnabled(deleteMissing("iamserviceaccount", []string{"--approve"}, nil)),
 		// eksctl delete fargate profile doens't has --only-missing command


### PR DESCRIPTION
In a8b085e59479f14a870033e1193fae4e07f2ea66 I had mistakenly added the `iam.withOIDC: true` existence check before updating IAM identity mappings. This fixes that.