### PR TITLE
Fix  'eksctl drain nodegroup' missing --region option

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -289,6 +289,8 @@ github.com/mitchellh/reflectwalk v1.0.1 h1:FVzMWA5RllMAKIdUSC8mdWo3XtwoecrH79BY7
 github.com/mitchellh/reflectwalk v1.0.1/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/mumoshu/gofish v0.13.1-0.20200908033248-ab2d494fb15c h1:psoQG0FYSJesI3ZNL6FDBQVMuS+xj7weacaEJ51Jzi4=
 github.com/mumoshu/gofish v0.13.1-0.20200908033248-ab2d494fb15c/go.mod h1:+tioljxX31bBiVquRFxuofNwXHDqeeJZrCXfsRUX7ec=
+github.com/mumoshu/shoal v0.2.18 h1:aazA6O1oXAbkJqyJSWdrVLwnj1vETeLf4fGW2QCZs9A=
+github.com/mumoshu/shoal v0.2.18/go.mod h1:TjMI6WkJ20NAhdP7xvXoDfd7EFpeSOh6xI34HMLRrHo=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=

--- a/pkg/resource/cluster/cluster_update.go
+++ b/pkg/resource/cluster/cluster_update.go
@@ -216,7 +216,7 @@ func (m *Manager) updateCluster(d *schema.ResourceData) (*ClusterSet, error) {
 				if v == false {
 					opt = append(opt, "--undo")
 				}
-				cmd, err := newEksctlCommandWithAWSProfile(cluster, opt...)
+				cmd, err := newEksctlCommandFromResourceWithRegionAndProfile(d, opt...)
 
 				if err != nil {
 					return fmt.Errorf("creating eksctl drain command: %w", err)


### PR DESCRIPTION
Fixed to run  'eksctl drain nodegroup` with --region option.