### PR TITLE
feat: `eksctl_nodegroup`

### DIFF
--- a/examples/lib/lib.mk
+++ b/examples/lib/lib.mk
@@ -1,5 +1,6 @@
 WORKSPACE ?= $(shell pwd)
 HELMFILE_ROOT ?= ../../../terraform-provider-helmfile
+KUBECTL_ROOT ?= ../../../terraform-provider-kubectl
 TERRAFORM ?= terraform
 
 .PHONY: build
@@ -7,16 +8,30 @@ build: VER=0.0.1
 build:
 	mkdir -p .terraform/plugins/darwin_amd64
 	cd ../..; make clean build
+	cd $(HELMFILE_ROOT); make build
+	cd $(KUBECTL_ROOT); make build
+	# For terraform up to v0.12
+	#
+	# eksctl
 	cp ../../dist/darwin_amd64/terraform-provider-eksctl $(WORKSPACE)/.terraform/plugins/darwin_amd64/
 	chmod +x $(WORKSPACE)/.terraform/plugins/darwin_amd64/terraform-provider-eksctl
-	cd $(HELMFILE_ROOT); make build
-	# For terraform up to v0.12
+	# helmfile
 	cp $(HELMFILE_ROOT)/dist/darwin_amd64/terraform-provider-helmfile $(WORKSPACE)/.terraform/plugins/darwin_amd64/
 	chmod +x $(WORKSPACE)/.terraform/plugins/darwin_amd64/terraform-provider-helmfile
+	# kubectl
+	cp $(KUBECTL_ROOT)/dist/darwin_amd64/terraform-provider-kubectl $(WORKSPACE)/.terraform/plugins/darwin_amd64/
+	chmod +x $(WORKSPACE)/.terraform/plugins/darwin_amd64/terraform-provider-kubectl
 	# For tereraform v0.13+
+	#
+	# eksctl
 	mkdir -p $(WORKSPACE)/.terraform/plugins/registry.terraform.io/mumoshu/eksctl/$(VER)/darwin_amd64/
 	cp ../../dist/darwin_amd64/terraform-provider-eksctl $(WORKSPACE)/.terraform/plugins/registry.terraform.io/mumoshu/eksctl/$(VER)/darwin_amd64/terraform-provider-eksctl_v$(VER)
 	chmod +x $(WORKSPACE)/.terraform/plugins/registry.terraform.io/mumoshu/eksctl/$(VER)/darwin_amd64/terraform-provider-eksctl_v$(VER)
+	# helmfile
 	mkdir -p $(WORKSPACE)/.terraform/plugins/registry.terraform.io/mumoshu/helmfile/$(VER)/darwin_amd64/
 	cp $(HELMFILE_ROOT)/dist/darwin_amd64/terraform-provider-helmfile $(WORKSPACE)/.terraform/plugins/registry.terraform.io/mumoshu/helmfile/$(VER)/darwin_amd64/terraform-provider-helmfile_v$(VER)
 	chmod +x $(WORKSPACE)/.terraform/plugins/registry.terraform.io/mumoshu/helmfile/$(VER)/darwin_amd64/terraform-provider-helmfile_v$(VER)
+	# kubectl
+	mkdir -p $(WORKSPACE)/.terraform/plugins/registry.terraform.io/mumoshu/kubectl/$(VER)/darwin_amd64/
+	cp $(KUBECTL_ROOT)/dist/darwin_amd64/terraform-provider-kubectl $(WORKSPACE)/.terraform/plugins/registry.terraform.io/mumoshu/kubectl/$(VER)/darwin_amd64/terraform-provider-kubectl_v$(VER)
+	chmod +x $(WORKSPACE)/.terraform/plugins/registry.terraform.io/mumoshu/kubectl/$(VER)/darwin_amd64/terraform-provider-kubectl_v$(VER)

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -6,6 +6,7 @@ import (
 	"github.com/mumoshu/terraform-provider-eksctl/pkg/resource/cluster"
 	"github.com/mumoshu/terraform-provider-eksctl/pkg/resource/courier"
 	"github.com/mumoshu/terraform-provider-eksctl/pkg/resource/iamserviceaccount"
+	"github.com/mumoshu/terraform-provider-eksctl/pkg/resource/nodegroup"
 	"github.com/mumoshu/terraform-provider-eksctl/pkg/sdk/tfsdk"
 )
 
@@ -19,6 +20,7 @@ func Provider() terraform.ResourceProvider {
 		},
 		ResourcesMap: map[string]*schema.Resource{
 			"eksctl_cluster":                cluster.ResourceCluster(),
+			"eksctl_nodegroup":              nodegroup.Resource(),
 			"eksctl_iamserviceaccount":      iamserviceaccount.Resource(),
 			"eksctl_courier_alb":            courier.ResourceALB(),
 			"eksctl_courier_route53_record": courier.ResourceRoute53Record(),

--- a/pkg/resource/nodegroup/context.go
+++ b/pkg/resource/nodegroup/context.go
@@ -1,0 +1,14 @@
+package nodegroup
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/mumoshu/terraform-provider-eksctl/pkg/sdk"
+	"github.com/mumoshu/terraform-provider-eksctl/pkg/sdk/tfsdk"
+)
+
+func mustContext(a *schema.ResourceData) *sdk.Context {
+	config := tfsdk.ConfigFromResourceData(a)
+	sess, creds := sdk.AWSCredsFromConfig(config)
+
+	return &sdk.Context{Sess: sess, Creds: creds}
+}

--- a/pkg/resource/nodegroup/resource.go
+++ b/pkg/resource/nodegroup/resource.go
@@ -1,0 +1,289 @@
+package nodegroup
+
+import (
+	"fmt"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/mumoshu/terraform-provider-eksctl/pkg/sdk"
+	"github.com/mumoshu/terraform-provider-eksctl/pkg/sdk/api"
+	"github.com/mumoshu/terraform-provider-eksctl/pkg/sdk/tfsdk"
+	"math/rand"
+	"os/exec"
+	"runtime/debug"
+	"strings"
+)
+
+type Op uint8
+
+const (
+	Create Op = 1 << iota
+	Delete
+)
+
+type Attr struct {
+	Key    string
+	Schema *schema.Schema
+	Args   func(d api.Getter) []string
+	Ops    Op
+}
+
+type SchemaOption func(*schema.Schema)
+
+type Tpe struct {
+	Type schema.ValueType
+	Elem *schema.Schema
+	Args func(key, flag string, def interface{}, d api.Getter) (args []string)
+}
+
+func NewAttr(name string, tpe Tpe, ops Op, opts ...SchemaOption) Attr {
+	key := strings.ReplaceAll(name, "-", "_")
+	flag := strings.ReplaceAll(name, "_", "-")
+
+	sc := &schema.Schema{
+		Type:     tpe.Type,
+		Elem:     tpe.Elem,
+		ForceNew: true,
+	}
+
+	for _, o := range opts {
+		o(sc)
+	}
+
+	if !sc.Required {
+		sc.Optional = true
+	}
+
+	return Attr{
+		Key:    key,
+		Schema: sc,
+		Args: func(d api.Getter) []string {
+			return tpe.Args(key, flag, sc.Default, d)
+		},
+		Ops: ops,
+	}
+}
+
+var String = Tpe{
+	Type: schema.TypeString,
+	Args: func(key, flag string, def interface{}, d api.Getter) (args []string) {
+		if v, ok := d.Get(key).(string); ok && v != "" {
+			args = append(args, "--"+flag, v)
+		}
+		return
+	},
+}
+
+var Bool = Tpe{
+	Type: schema.TypeBool,
+	Args: func(key, flag string, def interface{}, d api.Getter) (args []string) {
+		if v, ok := d.Get(key).(bool); ok {
+			if def != nil {
+				if def.(bool) != v {
+					args = append(args, "--"+flag)
+				}
+			} else if v {
+				args = append(args, "--"+flag)
+			}
+		}
+		return
+	},
+}
+
+var Int = Tpe{
+	Type: schema.TypeInt,
+	Args: func(key, flag string, def interface{}, d api.Getter) (args []string) {
+		if v, ok := d.Get(key).(int); ok {
+			if def != nil {
+				if def.(int) != v {
+					args = append(args, "--"+flag)
+				}
+			} else if v > 0 {
+				args = append(args, "--"+flag, fmt.Sprintf("%d", v))
+			}
+		}
+		return
+	},
+}
+
+var Strings = Tpe{
+	Type: schema.TypeList,
+	Elem: &schema.Schema{
+		Type: schema.TypeString,
+	},
+	Args: func(key, flag string, def interface{}, d api.Getter) (args []string) {
+		if vs, ok := d.Get(key).([]interface{}); ok && len(vs) > 0 {
+			var ss []string
+
+			for _, v := range vs {
+				ss = append(ss, fmt.Sprintf("%v", v))
+			}
+
+			args = append(args, "--"+flag, strings.Join(ss, ","))
+		}
+		return
+	},
+}
+
+var StringMap = Tpe{
+	Type: schema.TypeMap,
+	Elem: &schema.Schema{
+		Type: schema.TypeBool,
+	},
+	Args: func(key, flag string, def interface{}, d api.Getter) (args []string) {
+		if m, ok := d.Get(key).(map[string]interface{}); ok && len(m) > 0 {
+			var vs []string
+
+			for k, v := range m {
+				vs = append(vs, fmt.Sprintf("%s=%v", k, v))
+			}
+
+			args = append(args, "--"+flag, strings.Join(vs, ","))
+		}
+		return
+	},
+}
+
+func Required() func(sc *schema.Schema) {
+	return func(sc *schema.Schema) {
+		sc.Required = true
+	}
+}
+
+func Default(v interface{}) func(sc *schema.Schema) {
+	return func(sc *schema.Schema) {
+		sc.Default = v
+	}
+}
+
+const (
+	KeyEksctlVersion = "eksctl_version"
+)
+
+func Resource() *schema.Resource {
+	subresource := "nodegroup"
+
+	attrs := []Attr{
+		NewAttr("cluster", String, Create|Delete, Required()),
+		NewAttr("name", String, Create|Delete, Required()),
+		NewAttr(KeyEksctlVersion, String, Create|Delete),
+		NewAttr("tags", StringMap, Create),
+		NewAttr("region", String, Create|Delete),
+		NewAttr("version", String, Create),
+		NewAttr("node-type", String, Create),
+		NewAttr("nodes", Int, Create),
+		NewAttr("nodes-min", Int, Create),
+		NewAttr("nodes-max", Int, Create),
+		NewAttr("node-volume-size", Int, Create),
+		NewAttr("node-volume-type", Int, Create),
+		NewAttr("ssh-access", Bool, Create),
+		NewAttr("ssh-public-key", String, Create),
+		NewAttr("enable-ssm", Bool, Create),
+		NewAttr("node-ami", String, Create),
+		NewAttr("node-ami-family", String, Create),
+		NewAttr("node-private-networking", Bool, Create),
+		NewAttr("node-security-groups", Strings, Create),
+		NewAttr("node-labels", StringMap, Create),
+		NewAttr("node-zones", Strings, Create),
+		NewAttr("instance-prefix", String, Create),
+		NewAttr("instance-name", String, Create),
+		NewAttr("disable-pod-imds", Bool, Create),
+		NewAttr("managed", Bool, Create),
+		NewAttr("spot", Bool, Create),
+		NewAttr("drain", Bool, Delete, Default(true)),
+		NewAttr("instanec-types", Strings, Create),
+		NewAttr("asg-access", Bool, Create),
+		NewAttr("exernal-dns-access", Bool, Create),
+		NewAttr("full-ecr-access", Bool, Create),
+		NewAttr("appmesh-access", Bool, Create),
+		NewAttr("appmesh-preview-access", Bool, Create),
+		NewAttr("alb-ingress-access", Bool, Create),
+		NewAttr("install-neuron-plugin", Bool, Create),
+		NewAttr("install-nvidia-plugin", Bool, Create),
+		NewAttr("cfn-role-arn", String, Create),
+		NewAttr("cfn-disable-rollback", Bool, Create),
+	}
+
+	sc := map[string]*schema.Schema{
+		tfsdk.KeyAssumeRole: tfsdk.SchemaAssumeRole(),
+		sdk.KeyOutput: {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+	}
+
+	for _, attr := range attrs {
+		sc[attr.Key] = attr.Schema
+	}
+
+	return &schema.Resource{
+		Create: func(d *schema.ResourceData, meta interface{}) (finalErr error) {
+			defer func() {
+				if err := recover(); err != nil {
+					finalErr = fmt.Errorf("unhandled error: %v\n%s", err, debug.Stack())
+				}
+			}()
+
+			ctx := mustContext(d)
+
+			args := []string{
+				"create",
+				subresource,
+			}
+
+			for _, attr := range attrs {
+				if Create&attr.Ops != 0 {
+					args = append(args, attr.Args(d)...)
+				}
+			}
+
+			id := fmt.Sprintf("%d", rand.Int())
+
+			if err := ctx.Create(createCommand(d, args), d, id); err != nil {
+				return err
+			}
+
+			d.SetId(id)
+
+			return nil
+		},
+		Delete: func(d *schema.ResourceData, meta interface{}) (finalErr error) {
+			defer func() {
+				if err := recover(); err != nil {
+					finalErr = fmt.Errorf("unhandled error: %v\n%s", err, debug.Stack())
+				}
+			}()
+
+			ctx := mustContext(d)
+
+			args := []string{
+				"delete",
+				subresource,
+			}
+
+			for _, attr := range attrs {
+				if Delete&attr.Ops != 0 {
+					args = append(args, attr.Args(d)...)
+				}
+			}
+
+			return ctx.Delete(createCommand(d, args))
+		},
+		Read: func(d *schema.ResourceData, meta interface{}) error {
+			return nil
+		},
+		Update: func(d *schema.ResourceData, meta interface{}) error {
+			return nil
+		},
+		Schema: sc,
+	}
+}
+
+func createCommand(d api.Getter, args []string) *exec.Cmd {
+	eksctlVersion := d.Get(KeyEksctlVersion).(string)
+
+	eksctlBin, err := sdk.PrepareExecutable("eksctl", "eksctl", eksctlVersion)
+	if err != nil {
+		panic(fmt.Errorf("creating eksctl command: %w", err))
+	}
+
+	return exec.Command(*eksctlBin, args...)
+}

--- a/pkg/sdk/prepare_exec.go
+++ b/pkg/sdk/prepare_exec.go
@@ -25,9 +25,9 @@ func PrepareExecutable(defaultPath, pkgAndCmdName, pkgVersion string) (*string, 
 
 	rig := "https://github.com/fishworks/fish-food"
 
-	installEksctl := pkgVersion != ""
+	doInstall := pkgVersion != ""
 
-	if installEksctl {
+	if doInstall {
 		log.Printf("Installing %s %s", pkgAndCmdName, pkgVersion)
 
 		conf.Dependencies = append(conf.Dependencies,


### PR DESCRIPTION
In contrast to nodegroups embedded in `eksctl_cluster` `spec`, `eksctl_nodegroup` resources allows you to add/remove additional nodegroups to/from eksctl_cluster without calling many EKS APIs, which helps large scale deployment.