### PR TITLE
Fix harmless Fargate error checking

### DIFF
--- a/pkg/resource/cluster/cluster_update.go
+++ b/pkg/resource/cluster/cluster_update.go
@@ -195,9 +195,10 @@ func (m *Manager) updateCluster(d *schema.ResourceData) (*ClusterSet, error) {
 	clusterName := string(set.ClusterName)
 	harmlessFargateProfileCreationErrors := []string{
 		fmt.Sprintf(`Error: no output "FargatePodExecutionRoleARN" in stack "eksctl-%s-cluster"`, clusterName),
+		fmt.Sprintf(`Error: couldn't refresh role arn: no output "FargatePodExecutionRoleARN" in stack "eksctl-%s-cluster"`, clusterName),
 	}
 
-	draineNodegroup := func() func() error {
+	drainNodegroup := func() func() error {
 
 		return func() error {
 
@@ -273,7 +274,7 @@ func (m *Manager) updateCluster(d *schema.ResourceData) (*ClusterSet, error) {
 		whenIAMWithOIDCEnabled(createNew("iamserviceaccount", []string{"--approve"}, nil)),
 		createNew("fargateprofile", nil, harmlessFargateProfileCreationErrors),
 		enableRepo(),
-		draineNodegroup(),
+		drainNodegroup(),
 		updateIAMIdentityMapping(),
 		deleteMissing("nodegroup", []string{"--drain", "--approve"}, nil),
 		whenIAMWithOIDCEnabled(deleteMissing("iamserviceaccount", []string{"--approve"}, nil)),


### PR DESCRIPTION
Closes #40.

I've run across a slightly different error than the one that's currently being checked on the `harmlessFargateProfileCreationErrors` slice.

In the mentioned Issue, I've suggested something like checking with `strings.Contains` but I feel like that could ignore errors that aren't harmless in some cases (not quite sure though).

With this in mind, I've decided to simply add my variation of the error to the slice itself, this fixed my issue and now it works correctly.

I took the opportunity to fix a simple grammar typo as well if you don't mind.

Let me know if this needs to be changed in any way or if it simply isn't the best approach for it.