### PR TITLE
Fix element type of nodegroup StringMap to be a string instead of a bool

### DIFF
--- a/pkg/resource/nodegroup/resource.go
+++ b/pkg/resource/nodegroup/resource.go
@@ -126,7 +126,7 @@ var Strings = Tpe{
 var StringMap = Tpe{
 	Type: schema.TypeMap,
 	Elem: &schema.Schema{
-		Type: schema.TypeBool,
+		Type: schema.TypeString,
 	},
 	Args: func(key, flag string, def interface{}, d api.Getter) (args []string) {
 		if m, ok := d.Get(key).(map[string]interface{}); ok && len(m) > 0 {


### PR DESCRIPTION
The node-labels property of the nodegroup resource isn't currently usable because the StringMap currently requires bool values rather than string values.