### PR TITLE
fix: pass region to iamserviceaccount command

### DIFF
--- a/pkg/resource/iamserviceaccount/iamserviceaccount.go
+++ b/pkg/resource/iamserviceaccount/iamserviceaccount.go
@@ -28,6 +28,7 @@ func Resource() *schema.Resource {
 				"--cluster", a.Cluster,
 				"--name", a.Name,
 				"--namespace", a.Namespace,
+				"--region", a.Region,
 			}
 
 			if a.OverrideExistingServiceAccounts {
@@ -55,6 +56,7 @@ func Resource() *schema.Resource {
 				"--cluster", a.Cluster,
 				"--name", a.Name,
 				"--namespace", a.Namespace,
+				"--region", a.Region,
 			}
 
 			return ctx.Delete(exec.Command("eksctl", args...))


### PR DESCRIPTION
The iamserviceaccount resource has region as a required field, but the information in the field is not used in the eksctl arguments.  This causes failures when the region in the resource does not match the region in the environment.

This change adds the region to the create and delete arguments to fix the issue.