### PR TITLE
Bug: Only capture stdout

### DIFF
--- a/pkg/sdk/run.go
+++ b/pkg/sdk/run.go
@@ -24,7 +24,6 @@ func Run(cmd *exec.Cmd) (*CommandResult, error) {
 	if err != nil {
 		return nil, err
 	}
-	cmd.Stderr = pw
 	cmd.Stdout = pw
 
 	output, _ := circbuf.NewBuffer(maxBufSize)

--- a/pkg/sdk/run_test.go
+++ b/pkg/sdk/run_test.go
@@ -2,42 +2,11 @@ package sdk
 
 import (
 	"fmt"
-	"github.com/google/go-cmp/cmp"
 	"os/exec"
-	"strings"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
-
-func TestRun_err(t *testing.T) {
-	var repeats string
-	for i := 0; i < 2; i++ {
-		if repeats != "" {
-			repeats += "\n"
-		}
-		repeats = repeats + "stdout"
-	}
-	want := fmt.Sprintf(`running "/bin/bash bash -c echo stdout; echo stdout; echo stderr 1>&2; exit 1": exit status 1
-%s
-stderr
-`, repeats)
-
-	for i := 0; i < 10; i++ {
-		t.Run(fmt.Sprintf("%3d", i), func(t *testing.T) {
-			t.Parallel()
-
-			cmd := exec.Command("bash", "-c", "echo stdout; echo stdout; echo stderr 1>&2; exit 1")
-			//cmd.Stdin = bytes.NewReader([]byte("foo"))
-
-			if _, err := Run(cmd); err != nil {
-				if d := cmp.Diff(want, err.Error()); d != "" {
-					t.Fatalf("running %s %s:\n%s", cmd.Path, strings.Join(cmd.Args, " "), d)
-				}
-			} else {
-				t.Fatal("no expected error occuered")
-			}
-		})
-	}
-}
 
 func TestRun(t *testing.T) {
 	var repeats string
@@ -48,14 +17,13 @@ func TestRun(t *testing.T) {
 		repeats = repeats + "stdout"
 	}
 	want := fmt.Sprintf(`%s
-stderr
 `, repeats)
 
 	for i := 0; i < 10; i++ {
 		t.Run(fmt.Sprintf("%3d", i), func(t *testing.T) {
 			t.Parallel()
 
-			cmd := exec.Command("bash", "-c", "echo stdout; echo stdout; echo stderr 1>&2")
+			cmd := exec.Command("bash", "-c", "echo stdout; echo stdout;")
 			//cmd.Stdin = bytes.NewReader([]byte("foo"))
 
 			if r, err := Run(cmd); err != nil {


### PR DESCRIPTION
https://github.com/mumoshu/terraform-provider-eksctl/issues/62

eksctl writes various information to stderr that don't have anything to do with json output. Remove the capture on stderr to avoid false positives when parsing the output.