### PR TITLE
chore: upgrade to go1.19

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
       name: Set up Go
       uses: actions/setup-go@v1
       with:
-        go-version: 1.16.x
+        go-version: 1.19.x
     # See https://goreleaser.com/ci/actions/#signing
     -
       name: Import GPG key

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/mumoshu/terraform-provider-eksctl
 
-go 1.16
+go 1.19
 
 require (
 	github.com/armon/circbuf v0.0.0-20190214190532-5111143e8da2
@@ -15,6 +15,95 @@ require (
 	golang.org/x/sync v0.0.0-20190423024810-112230192c58
 	golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543
 	gopkg.in/yaml.v3 v3.0.0-20200506231410-2ff61e1afc86
+)
+
+require (
+	cloud.google.com/go v0.45.1 // indirect
+	github.com/Masterminds/semver v1.5.0 // indirect
+	github.com/Masterminds/vcs v1.13.1 // indirect
+	github.com/agext/levenshtein v1.2.2 // indirect
+	github.com/andybalholm/brotli v0.0.0-20190621154722-5f990b63d2d6 // indirect
+	github.com/apparentlymart/go-cidr v1.0.1 // indirect
+	github.com/apparentlymart/go-textseg v1.0.0 // indirect
+	github.com/armon/go-radix v1.0.0 // indirect
+	github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d // indirect
+	github.com/bgentry/speakeasy v0.1.0 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/dsnet/compress v0.0.1 // indirect
+	github.com/emirpasic/gods v1.12.0 // indirect
+	github.com/fatih/color v1.9.0 // indirect
+	github.com/fishworks/gofish v0.13.1-0.20200806145805-309ee2606318 // indirect
+	github.com/go-git/gcfg v1.5.0 // indirect
+	github.com/go-git/go-billy/v5 v5.0.0 // indirect
+	github.com/go-git/go-git/v5 v5.1.0 // indirect
+	github.com/golang/gddo v0.0.0-20190419222130-af0f2af80721 // indirect
+	github.com/golang/protobuf v1.3.2 // indirect
+	github.com/golang/snappy v0.0.1 // indirect
+	github.com/google/uuid v1.1.1 // indirect
+	github.com/googleapis/gax-go/v2 v2.0.5 // indirect
+	github.com/hashicorp/errwrap v1.0.0 // indirect
+	github.com/hashicorp/go-cleanhttp v0.5.1 // indirect
+	github.com/hashicorp/go-getter v1.4.0 // indirect
+	github.com/hashicorp/go-hclog v0.9.2 // indirect
+	github.com/hashicorp/go-multierror v1.0.0 // indirect
+	github.com/hashicorp/go-plugin v1.0.1 // indirect
+	github.com/hashicorp/go-safetemp v1.0.0 // indirect
+	github.com/hashicorp/go-uuid v1.0.1 // indirect
+	github.com/hashicorp/go-version v1.2.0 // indirect
+	github.com/hashicorp/golang-lru v0.5.1 // indirect
+	github.com/hashicorp/hcl v1.0.0 // indirect
+	github.com/hashicorp/hcl2 v0.0.0-20190821123243-0c888d1241f6 // indirect
+	github.com/hashicorp/hil v0.0.0-20190212112733-ab17b08d6590 // indirect
+	github.com/hashicorp/logutils v1.0.0 // indirect
+	github.com/hashicorp/terraform-config-inspect v0.0.0-20190821133035-82a99dc22ef4 // indirect
+	github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d // indirect
+	github.com/imdario/mergo v0.3.9 // indirect
+	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
+	github.com/jmespath/go-jmespath v0.4.0 // indirect
+	github.com/kevinburke/ssh_config v0.0.0-20190725054713-01f96b0aa0cd // indirect
+	github.com/klauspost/compress v1.9.2 // indirect
+	github.com/klauspost/pgzip v1.2.1 // indirect
+	github.com/konsorten/go-windows-terminal-sequences v1.0.1 // indirect
+	github.com/kyokomi/emoji v2.2.2+incompatible // indirect
+	github.com/mattn/go-colorable v0.1.4 // indirect
+	github.com/mattn/go-isatty v0.0.11 // indirect
+	github.com/mholt/archiver/v3 v3.3.0 // indirect
+	github.com/mitchellh/cli v1.0.0 // indirect
+	github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db // indirect
+	github.com/mitchellh/copystructure v1.0.0 // indirect
+	github.com/mitchellh/go-homedir v1.1.0 // indirect
+	github.com/mitchellh/go-testing-interface v1.0.0 // indirect
+	github.com/mitchellh/go-wordwrap v1.0.0 // indirect
+	github.com/mitchellh/mapstructure v1.1.2 // indirect
+	github.com/mitchellh/reflectwalk v1.0.1 // indirect
+	github.com/nwaples/rardecode v1.1.0 // indirect
+	github.com/oklog/run v1.0.0 // indirect
+	github.com/pierrec/lz4 v2.5.1+incompatible // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/posener/complete v1.2.1 // indirect
+	github.com/sergi/go-diff v1.1.0 // indirect
+	github.com/sirupsen/logrus v1.5.0 // indirect
+	github.com/spf13/afero v1.2.2 // indirect
+	github.com/ulikunitz/xz v0.5.7 // indirect
+	github.com/vmihailenco/msgpack v3.3.3+incompatible // indirect
+	github.com/xanzy/ssh-agent v0.2.1 // indirect
+	github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 // indirect
+	github.com/yuin/gluamapper v0.0.0-20150323120927-d836955830e7 // indirect
+	github.com/yuin/gopher-lua v0.0.0-20191220021717-ab39c6098bdb // indirect
+	github.com/zclconf/go-cty v1.1.0 // indirect
+	github.com/zclconf/go-cty-yaml v1.0.1 // indirect
+	go.opencensus.io v0.22.0 // indirect
+	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9 // indirect
+	golang.org/x/net v0.0.0-20201110031124-69a78807bb2b // indirect
+	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45 // indirect
+	golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f // indirect
+	golang.org/x/text v0.3.3 // indirect
+	google.golang.org/api v0.9.0 // indirect
+	google.golang.org/appengine v1.6.1 // indirect
+	google.golang.org/genproto v0.0.0-20190819201941-24fa4b261c55 // indirect
+	google.golang.org/grpc v1.23.0 // indirect
+	gopkg.in/warnings.v0 v0.1.2 // indirect
+	gopkg.in/yaml.v2 v2.2.8 // indirect
 )
 
 replace github.com/fishworks/gofish => github.com/mumoshu/gofish v0.13.1-0.20200908033248-ab2d494fb15c

--- a/pkg/courier/alb.go
+++ b/pkg/courier/alb.go
@@ -2,14 +2,15 @@ package courier
 
 import (
 	"fmt"
+	"log"
+	"strconv"
+	"time"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/elbv2"
 	"github.com/mumoshu/terraform-provider-eksctl/pkg/sdk"
 	"golang.org/x/xerrors"
-	"log"
-	"strconv"
-	"time"
 )
 
 type CourierALB struct {
@@ -65,7 +66,7 @@ func (a *ALB) Delete(d *CourierALB) error {
 				appendix = fmt.Sprintf("\nOUTPUT:\n%v", *res)
 			}
 
-			log.Printf("Error: deleting rule: %w\nINPUT:\n%v%s", err, *input, appendix)
+			log.Printf("Error: deleting rule: %s\nINPUT:\n%v%s", err.Error(), *input, appendix)
 
 			return fmt.Errorf("deleting rule: %w", err)
 		}

--- a/pkg/resource/cluster/cluster_read.go
+++ b/pkg/resource/cluster/cluster_read.go
@@ -69,7 +69,7 @@ func (m *Manager) readClusterInternal(d api.Resource) (*Cluster, error) {
 	}
 
 	if err := d.Set(KeyTargetGroupARNs, v); err != nil {
-		log.Printf("setting resource data value for key %v: %w", KeyTargetGroupARNs, err)
+		log.Printf("setting resource data value for key %v: %s", KeyTargetGroupARNs, err.Error())
 	}
 
 	c, err := ReadCluster(d)

--- a/pkg/resource/cluster/delete_k8s_resources.go
+++ b/pkg/resource/cluster/delete_k8s_resources.go
@@ -1,13 +1,14 @@
 package cluster
 
 import (
-	"github.com/mumoshu/terraform-provider-eksctl/pkg/sdk"
-	"golang.org/x/xerrors"
 	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"
 	"strings"
+
+	"github.com/mumoshu/terraform-provider-eksctl/pkg/sdk"
+	"golang.org/x/xerrors"
 )
 
 func doDeleteKubernetesResourcesBeforeDestroy(ctx *sdk.Context, cluster *Cluster, id string) error {
@@ -50,7 +51,7 @@ func doDeleteKubernetesResourcesBeforeDestroy(ctx *sdk.Context, cluster *Cluster
 
 		if _, err := ctx.Run(kubectlCmd); err != nil {
 			if strings.Contains(err.Error(), "not found") {
-				log.Printf("Ignoring `kubectl delete` error %w. %s/%s/%s seems already deleted. Perhaps it is a stale cluster that was in the middle of deletion process?", err, d.Namespace, d.Kind, d.Name)
+				log.Printf("Ignoring `kubectl delete` error %s. %s/%s/%s seems already deleted. Perhaps it is a stale cluster that was in the middle of deletion process?", err.Error(), d.Namespace, d.Kind, d.Name)
 				continue
 			}
 

--- a/pkg/resource/cluster/traffic_shift.go
+++ b/pkg/resource/cluster/traffic_shift.go
@@ -2,14 +2,15 @@ package cluster
 
 import (
 	"context"
+	"log"
+	"sync"
+	"time"
+
 	"github.com/aws/aws-sdk-go/service/elbv2"
 	"github.com/aws/aws-sdk-go/service/elbv2/elbv2iface"
 	"github.com/mumoshu/terraform-provider-eksctl/pkg/courier"
 	"golang.org/x/sync/errgroup"
 	"golang.org/x/xerrors"
-	"log"
-	"sync"
-	"time"
 )
 
 func graduallyShiftTraffic(set *ClusterSet, opts courier.CanaryOpts) error {
@@ -106,7 +107,7 @@ func (m *ALBRouter) SwitchTargetGroup(listenerStatuses ListenerStatuses, opts co
 
 		return err
 	} else {
-		log.Printf("Traffic shifting canceled due to error: %w", err)
+		log.Printf("Traffic shifting canceled due to error: %s", err.Error())
 
 		return err
 	}


### PR DESCRIPTION
Builds failing because new version of goreleases doesn't filter out windows/arm64 which only is support in go 1.17 onwards

update release workflows
update go.mod
%w isn't support in print use %s and convert error to string